### PR TITLE
Updated to cope with strangely named services and devices

### DIFF
--- a/lib/mios/device.rb
+++ b/lib/mios/device.rb
@@ -55,6 +55,10 @@ module MiOS
       nil
     end
     
+    def is_num? (str_to_test)
+      !!(str_to_test =~ /^[-+]?[0-9]+$/)
+    end
+
     def parse(data, skip_attributes=false)
 
       @attributes = Hash[
@@ -65,7 +69,8 @@ module MiOS
       
       @states = data['states']
       @states.map { |state|
-        state['service'].split(":").last
+        parts = state['service'].split(":")
+        parts.select{ |elem| !is_num?(elem)}.last 
       }.uniq.each { |service|
         if MiOS::Services.const_defined?(service)
           extend MiOS::Services.const_get(service)
@@ -73,7 +78,7 @@ module MiOS
           $stderr.puts "WARNING: #{service} not yet supported"
         end
       }
-      
+     
       true
     end
   end

--- a/lib/mios/services/binary_light1.rb
+++ b/lib/mios/services/binary_light1.rb
@@ -1,0 +1,25 @@
+module MiOS
+  module Services
+    module BinaryLight
+      def self.extended(base)
+        base.instance_variable_set("@switchpower1_urn", "urn:schemas-upnp-org:device:BinaryLight:1")
+      end
+
+      def on?
+        boolean_for(@switchpower1_urn, 'Status')
+      end
+      
+      def off?
+        !on?
+      end
+      
+      def on!(async=false, &block)
+        set(@switchpower1_urn, "SetTarget", {"newTargetValue" => 1}, async, &block)
+      end
+
+      def off!(async=false, &block)
+        set(@switchpower1_urn, "SetTarget", {"newTargetValue" => 0}, async, &block)
+      end
+    end
+  end
+end

--- a/lib/mios/services/day_time.rb
+++ b/lib/mios/services/day_time.rb
@@ -1,0 +1,17 @@
+module MiOS
+  module Services
+    module DayTime
+      def self.extended(base)
+        base.instance_variable_set("@switchpower1_urn", "urn:rts-services-com:serviceId:DayTime")
+      end
+
+      def day?
+        boolean_for(@switchpower1_urn, 'Status')
+      end
+      
+      def night?
+        !day?
+      end
+    end
+  end
+end

--- a/lib/mios/services/ios_push1.rb
+++ b/lib/mios/services/ios_push1.rb
@@ -1,0 +1,9 @@
+module MiOS
+  module Services
+    module IOSPush1
+      def self.extended(base)
+        base.instance_variable_set("@iospush1_urn", "urn:schemas-upnp-org:service:IOSPush:1")
+      end
+    end
+  end
+end

--- a/lib/mios/services/motion_sensor1.rb
+++ b/lib/mios/services/motion_sensor1.rb
@@ -1,0 +1,33 @@
+module MiOS
+  module Services
+    module MotionSensor
+      def self.extended(base)
+        base.instance_variable_set("@securitysensor1_urn", "urn:micasaverde-com:serviceId:SecuritySensor1")
+      end
+
+      def tripped?
+        boolean_for(@securitysensor1_urn, 'Tripped')
+      end
+      
+      def armed?
+        boolean_for(@securitysensor1_urn, 'Armed')
+      end
+      
+      def disarmed?
+        !armed?
+      end
+      
+      def lasttrip
+        timestamp_for(@securitysensor1_urn, 'LastTrip')
+      end
+      
+      def arm!(async=false, &block)
+        set(@securitysensor1_urn, "SetArmed", {"newArmedValue" => 1}, async, &block)
+      end
+
+      def disarm!(async=false, &block)
+        set(@securitysensor1_urn, "SetArmed", {"newArmedValue" => 0}, async, &block)
+      end
+    end
+  end
+end

--- a/lib/mios/services/rain8_net.rb
+++ b/lib/mios/services/rain8_net.rb
@@ -1,0 +1,22 @@
+module MiOS
+  module Services
+    module Rain8Net1
+      def self.extended(base)
+        base.instance_variable_set("@rain8net_urn", "urn:wgldesigns-com:serviceId:Rain8Net:1")
+        base.instance_variable_set("@hadevice_urn", "urn:micasaverde-com:serviceId:HaDevice1")
+      end
+
+      def comm_failure?
+        boolean_for(@hadevice_urn, 'CommFailure')
+      end
+
+      def poll
+        value_for(@hadevice_urn, "Poll")
+      end
+
+      def last_state
+        value_for(@hadevice_urn, "State")
+      end
+    end
+  end
+end

--- a/lib/mios/services/virtual_switch1.rb
+++ b/lib/mios/services/virtual_switch1.rb
@@ -1,0 +1,25 @@
+module MiOS
+  module Services
+    module VSwitch1
+      def self.extended(base)
+        base.instance_variable_set("@switchpower1_urn", "urn:upnp-org:serviceId:VSwitch1")
+      end
+
+      def on?
+        boolean_for(@switchpower1_urn, 'Status')
+      end
+      
+      def off?
+        !on?
+      end
+      
+      def on!(async=false, &block)
+        set(@switchpower1_urn, "SetTarget", {"newTargetValue" => 1}, async, &block)
+      end
+
+      def off!(async=false, &block)
+        set(@switchpower1_urn, "SetTarget", {"newTargetValue" => 0}, async, &block)
+      end
+    end
+  end
+end

--- a/lib/mios/services/world_weather1.rb
+++ b/lib/mios/services/world_weather1.rb
@@ -1,0 +1,29 @@
+module MiOS
+  module Services
+    module Weather1
+      def self.extended(base)
+        base.instance_variable_set("@worldweather_urn", "urn:upnp-micasaverde-com:serviceId:Weather1")
+      end
+
+      def location
+        value_for(@worldweather_urn, "Location")
+      end
+
+      def metric?
+        boolean_for(@worldweather_urn, "Metric")
+      end
+
+      def last_update
+        value_for(@worldweather_urn, "LastUpdate")
+      end
+
+      def condition
+        value_for(@worldweather_urn, "Condition")
+      end
+
+      def wind
+        { :condition => value_for(@worldweather_urn, "WindCondition"), :direction => value_for(@worldweather_urn, "WindDirection"), :speed => value_for(@worldweather_urn, "WindSpeed")}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some devices seem to be named Device:1 rather than Device1, added a
test for numerical value and selecting the service from the array of
parts.

There might be a better way to do it.
