### PR TITLE
Fix Humidity Sensor

### DIFF
--- a/lib/mios/services/humidity_sensor1.rb
+++ b/lib/mios/services/humidity_sensor1.rb
@@ -1,12 +1,12 @@
-# NOTE: Currently untested with a real humidity sensor
+# Tested with Everspring Combo Sensor
 module MiOS
   module Services
     module HumiditySensor1
 
-      URN = 'urn:upnp-org:serviceId:HumiditySensor1'
+      URN = 'urn:micasaverde-com:serviceId:HumiditySensor1'
 
       def humidity
-        value_for URN, 'CurrentHumidity', as: Integer
+        value_for URN, 'CurrentLevel', as: Integer
       end
     end
   end


### PR DESCRIPTION
Prior to this commit the humidity sensor urn was incorrect and caused
zero to be returned. This commit fixes both that and the variable name
to be correct per the [mios
wiki](http://wiki.mios.com/index.php/Luup_UPNP_Files#HumiditySensor1)

Tested with the [Everspring Combo
Device](http://www.amazon.com/gp/product/B0078FD8FY)
