### PR TITLE
Fix missing comma

### DIFF
--- a/lib/mios/services/temperature_sensor1.rb
+++ b/lib/mios/services/temperature_sensor1.rb
@@ -5,7 +5,7 @@ module MiOS
       URN = 'urn:upnp-org:serviceId:TemperatureSensor1'
 
       def temperature
-        value_for URN 'CurrentTemperature', as: Integer
+        value_for URN, 'CurrentTemperature', as: Integer
       end
     end
   end


### PR DESCRIPTION
Prior to this commit temperature method caused a stack trace in the new
gem version due to a missing comma